### PR TITLE
Rename label `sales_order_id` to `sales_order` for consistency and clarity

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -32,7 +32,7 @@ type ReportArgs struct {
 	OverrideSalesOrderID        string
 }
 
-const SalesOrderIDLabel = "sales_order_id"
+const SalesOrderLabel = "sales_order"
 
 // RunRange executes prometheus queries like Run() until the `until` timestamp is reached or an error occurred.
 // Returns the number of reports run and a possible error.
@@ -110,7 +110,7 @@ func processSample(ctx context.Context, odooClient OdooClient, args ReportArgs, 
 	if args.OverrideSalesOrderID != "" {
 		salesOrderID = args.OverrideSalesOrderID
 	} else {
-		sid, err := getMetricLabel(s.Metric, SalesOrderIDLabel)
+		sid, err := getMetricLabel(s.Metric, SalesOrderLabel)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -36,7 +36,7 @@ const promTestquery = `
 			),
 			"tenant", "my-tenant", "", ""
 		),
-	"sales_order_id", "SO00000", "", ""
+	"sales_order", "SO00000", "", ""
 	)
 `
 const promInvalidTestquery = `


### PR DESCRIPTION
## Summary

* The label used for deriving the correct Sales Order is now expected as `sales_order` instead of `sales_order_id` (since the label value does not actually correspond to the ID of the sales order in Odoo, but to the name). This breaks existing queries which provide the old `sales_order_id` label. 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
