### PR TITLE
Improve progress reporting

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/appuio/appuio-reporting/pkg/odoo"
@@ -103,18 +102,6 @@ func runQuery(ctx context.Context, odooClient OdooClient, prom PromQuerier, args
 		} else {
 			records = append(records, *record)
 		}
-	}
-
-	// print the records to stdout for preview
-	for _, record := range records {
-		m, err := json.Marshal(record)
-		if err != nil {
-			// can't use the logger from the context here, since the required context key is in the main package 🙃
-			// TODO(bastjan) fix the suboptimal and overcomplicated logging setup
-			fmt.Fprintf(os.Stderr, "warning: failed to marshal record for preview: %+v; error: %s\n", record, err)
-			continue
-		}
-		fmt.Fprintf(os.Stdout, "%s\n", m)
 	}
 
 	return multierr.Append(errs, odooClient.SendData(ctx, records))

--- a/report_command.go
+++ b/report_command.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/appuio/appuio-reporting/pkg/odoo"
@@ -122,8 +121,11 @@ func (cmd *reportCommand) runReportRange(ctx context.Context, odooClient *odoo.O
 
 	started := time.Now()
 	reporter := report.WithProgressReporter(func(p report.Progress) {
-		fmt.Fprintf(os.Stderr, "Report %d, Current: %s [%s]\n",
-			p.Count, p.Timestamp.Format(time.RFC3339), time.Since(started).Round(time.Second),
+		log.Info("Progress report",
+			"product", cmd.ReportArgs.ProductID,
+			"reportIndex", p.Count,
+			"timestamp", p.Timestamp.Format(time.RFC3339),
+			"timeElapsed", time.Since(started).Round(time.Second),
 		)
 	})
 


### PR DESCRIPTION
## Summary

* I changed the log line that reports on progress after each query run to include more useful details. These are particularly needed for the use-case of backfilling data over a larger timeframe and across multiple products - it needs to be visible at all time where the processing currently is, so that it can be restarted in the case of transient errors.
* I furthermore removed the printing of the query results. It is extremely spammy, printing up to a hundred results for each timestep, making the progress report log lines impossible to find (or keep in scrollback buffer) while providing little actual utility.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
